### PR TITLE
docs: 알림 테이블 정의서 및 비동기 테크스팩 문서화

### DIFF
--- a/docs/domain-tech-spec/ASYNC_TECH_SPEC.md
+++ b/docs/domain-tech-spec/ASYNC_TECH_SPEC.md
@@ -1,0 +1,147 @@
+# 배경 (Background)
+
+- 프로젝트 목표: 알림/채팅/집계 처리를 비동기화해 응답 지연과 장애 전파를 줄인다.
+- 문제 정의:
+  - 동기 처리만으로는 이벤트 처리 지연과 리소스 경쟁이 발생한다.
+  - 실시간 전달(SSE/WS)과 저장은 분리되어야 유실을 방지할 수 있다.
+
+# 목표가 아닌 것 (Non-goals)
+
+- 글로벌 멀티리전 메시징
+- 스트림 분석/리플레이 기반 BI
+- 알림 등급(중요/일반) 분리 정책
+
+# 설계 및 기술 자료 (Architecture and Technical Documentation)
+
+## 사용 기술
+
+- 메시지 브로커: RabbitMQ
+- 실시간 전송: Redis Pub/Sub + SSE
+- 채팅 실시간: WebSocket
+- 저장소: MySQL
+
+## 비동기 이벤트 흐름 정의
+
+- 팔로우 생성: `FollowCreated` → NotificationWorker
+- 팔로우 해제: `FollowDeleted` → AggregateWorker
+- 게시글 좋아요: `PostLiked` → NotificationWorker
+- 댓글 생성: `CommentCreated` → NotificationWorker
+- 투표 종료: `VoteClosed` → NotificationWorker
+- 채팅 메시지 전송: `ChatMessageSent` → ChatPersistWorker, RealtimeFanoutWorker
+
+## 메시지 브로커/큐 선정
+
+- RabbitMQ 선택
+  - 내구성 보장, 재시도/DLQ 지원, 운영 도구 성숙.
+  - 알림 저장/재처리 요구를 만족.
+- Redis 역할
+  - 실시간 전달 전용(Pub/Sub).
+  - 저장/재처리는 RabbitMQ + DB로 수행.
+
+## 이벤트 스키마(메시지 포맷)
+
+- 공통 필드:
+  - eventId (UUID)
+  - eventType
+  - occurredAt (ISO8601)
+  - actorId
+  - targetId
+  - refId (post/comment/vote 등)
+  - payload (타입별 상세)
+
+## 큐/토픽 구성
+
+- exchange: `domain_events`
+- queue:
+  - `notification_queue`
+  - `aggregate_queue`
+  - `chat_persist_queue`
+  - `chat_fanout_queue`
+- DLQ:
+  - `notification_dlq`
+  - `aggregate_dlq`
+  - `chat_persist_dlq`
+  - `chat_fanout_dlq`
+
+## 비동기 작업(Worker) 로직
+
+### NotificationWorker
+1) RabbitMQ 이벤트 수신
+2) 알림 엔티티 DB 저장
+3) Redis Pub/Sub으로 실시간 전송(SSE)
+
+### AggregateWorker
+- 팔로우/투표/좋아요 집계 업데이트(멱등 처리)
+
+### ChatPersistWorker
+- 채팅 메시지 DB 저장(실패 시 재시도)
+
+### RealtimeFanoutWorker
+- Redis Pub/Sub로 실시간 팬아웃
+
+## 집계 카운트 처리 정책 (댓글/게시글/좋아요)
+
+- 집계는 Redis를 기준으로 처리하며, DB는 최종 동기화 대상으로 둔다.
+- 실시간 토글/생성 시 Redis에서 카운트를 증감하고, 비동기로 DB에 반영한다.
+- Redis는 집계의 실시간 소스로 사용하고, DB는 배치/이벤트 기반으로 수렴시킨다.
+- 클라이언트에는 항상 절대값 카운트를 응답하며, 클라이언트는 값을 덮어쓰기만 한다.
+- 서버가 DB/Redis 값을 합산해 최종 카운트를 계산하고, 클라이언트 합산 로직은 사용하지 않는다.
+- Redis 값이 없거나 조회 실패 시 DB 값을 fallback으로 사용한다.
+
+## SSE 스트림 API 스펙
+
+### 엔드포인트
+- `GET /api/notifications/stream`
+
+### 인증
+- `Authorization: Bearer {AT}` 헤더 기반
+
+### 응답 헤더
+SSE/HTTP 표준에 따른 권장 설정  
+
+- `Content-Type: text/event-stream`
+- `Cache-Control: no-cache`
+- `Connection: keep-alive`
+
+### 이벤트 포맷
+```
+id: {eventId}
+event: notification
+data: {"id":1,"type":"POST_LIKE","message":"...","refId":100}
+
+```
+
+### 재연결/재전송 정책
+- 클라이언트는 자동 재연결(EventSource 기본 동작).
+- 서버는 재접속 시 최근 10건의 미수신 알림을 재전송한다: 재접속 직후 UX를 보장하면서도 과도한 재전송 부하를 방지하기 위함.
+- 미수신 기준은 `read_at is null`이며, 최근 20건을 `created_at desc`로 조회한다.
+
+### 동시 접속 제한
+- 사용자당 SSE 연결은 1개만 허용한다.
+- 신규 연결이 들어오면 기존 연결을 종료한다.
+
+## 알림 저장/보관 정책
+
+- 알림은 DB에 저장한다.
+- 읽음 처리 후 7일이 지나면 삭제한다.
+- 미읽음 알림은 보관 기간 제한 없이 유지한다.
+
+## SSE vs WebSocket 선택 근거
+
+- 알림은 단방향이므로 SSE가 적합.
+- 채팅은 양방향이므로 WebSocket을 사용한다.
+
+## 이외 고려사항들 (Other Considerations)
+
+- SSE 연결은 인스턴스별로 유지되므로, 수평 확장 시 Sticky Session 또는 Redis Pub/Sub을 고려한다.
+- 알림 조회 API는 커서 기반 인피니티 스크롤로 동작한다.
+
+## 관련 도메인 문서
+
+- `docs/domain-tech-spec/NOTIFICATION_TECH_SPEC.md`
+- `docs/domain-tech-spec/CHAT_TECH_SPEC.md`
+
+# 용어 정의 (Glossary)
+
+- SSE: Server-Sent Events, 서버 → 클라이언트 단방향 스트림
+- DLQ: Dead Letter Queue, 재시도 실패 메시지 보관 큐

--- a/docs/domain-tech-spec/NOTIFICATION_TECH_SPEC.md
+++ b/docs/domain-tech-spec/NOTIFICATION_TECH_SPEC.md
@@ -1,0 +1,40 @@
+# 알림 도메인 테크 스펙 (Notification)
+
+## 배경 (Background)
+
+- 사용자 행동에 따른 알림을 저장하고 목록을 제공한다.
+- 실시간 전달/재시도 정책은 비동기 테크 스펙에서 다룬다.
+
+## 목표가 아닌 것 (Non-goals)
+
+- 모바일 푸시(Firebase)
+- 개인화 추천 알림
+
+## 설계 및 기술 자료 (Architecture and Technical Documentation)
+
+### 핵심 정책
+
+- 저장형 알림(DB 저장 우선)
+- 알림 목록 조회는 커서 기반 인피니티 스크롤
+- 읽음 처리/보관 정책은 테이블 정의서 기준
+
+### 데이터 스키마
+
+- 테이블 정의서: `docs/table/NOTIFICATIONS.md`
+- ref_id는 notification_type으로 해석해 대상 리소스를 식별한다.
+- actor 정보는 스냅샷으로 저장한다.
+- notification_type은 ENUM으로 관리한다.
+- 투표 종료 알림은 투표 생성자와 참여자에게 발송한다.
+
+## API 명세 (API Specifications)
+
+- 알림 목록: `GET /api/notifications`
+- 읽음 처리: `PATCH /api/notifications/{id}`
+
+## 보안 고려사항
+
+- 알림 조회는 인증 사용자만 허용
+
+## 비동기 연동
+
+- SSE/브로커/재전송 정책은 `docs/domain-tech-spec/ASYNC_TECH_SPEC.md` 참고

--- a/docs/table/NOTIFICATIONS.md
+++ b/docs/table/NOTIFICATIONS.md
@@ -1,0 +1,46 @@
+# Notifications
+
+## 1) 테이블 설명
+사용자에게 전달되는 알림 내역을 저장하는 테이블.  
+알림은 이벤트 스냅샷(행위자 닉네임/프로필, 메시지)을 보관하며, 조회는 수신자 기준 최신순으로 제공한다.
+
+## 2) 관계
+- members(1) : notifications(N) (recipient 기준)
+- members(1) : notifications(N) (actor 기준, nullable)
+
+## 3) 설계 근거
+- 알림은 이벤트성 로그이므로 대리키(id) 사용.
+- actor 정보는 스냅샷으로 저장해 닉네임/프로필 변경 영향 최소화.
+- ref_id로 대상 리소스(게시글/투표 등) 연결.
+- 알림 센터 목록 조회를 위해 수신자 기준 최신순 정렬/페이징을 고려.
+- ref_id는 다수 테이블의 FK를 담지만, 타입은 애플리케이션 계층에서 분기해 해석하므로 정합성 이슈가 없다.
+
+## 4) 컬럼 정의
+| No | 컬럼 | 타입 | 제약 | 설명 |
+| --- | --- | --- | --- | --- |
+| 1 | id | BIGINT | pk, nn | 알림 식별자 |
+| 2 | recipient_id | BIGINT | fk, nn | 수신자 |
+| 3 | actor_id | BIGINT | fk | 행위자(시스템 알림은 null) |
+| 4 | notification_type | ENUM(NotificationType) | nn | 알림 유형 |
+| 5 | actor_nickname_snapshot | VARCHAR(20) | nn | 행위자 닉네임 스냅샷 |
+| 6 | actor_profile_image_object_key_snapshot | VARCHAR(1024) |  | 행위자 프로필 이미지 스냅샷(오브젝트 키) |
+| 7 | message | VARCHAR(255) | nn | 알림 메시지 |
+| 8 | ref_id | BIGINT | nn | 대상 리소스 ID |
+| 9 | created_at | DATETIME | nn | 생성 시각 |
+| 10 | read_at | DATETIME |  | 읽음 시각 |
+
+### 알림 유형(NotificationType)
+| 유형 | 의미 |
+| --- | --- |
+| FOLLOW | 다른 사용자가 나를 팔로우 |
+| POST_LIKE | 다른 사용자가 내 게시글을 좋아요 |
+| POST_COMMENT | 다른 사용자가 내 게시글에 댓글 작성 |
+| VOTE_CLOSED | 내가 만든 투표 또는 참여했던 투표가 종료 |
+
+## 5) 인덱스/제약
+- `idx_notifications_recipient_created (recipient_id, created_at)`: 수신자별 최신순 목록 조회 최적화.
+
+## 6) 운영 정책
+- 읽음(read_at) 기록 후 7일 경과 시 삭제.
+- 미읽음은 삭제하지 않고 유지.
+- 알림 내용 보존을 위해 스냅샷(actor 닉네임/프로필) 저장


### PR DESCRIPTION
# 작업 개요(#82 #83)
- `docs`: 알림 테이블 정의서 및 비동기 테크스팩 문서화

### 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 문서 수정
- [ ] 테스트 코드 추가
- [ ] 기타