### PR TITLE
refactor: OCP 기반 SSE 공통 로직 분리

### DIFF
--- a/src/main/java/katopia/fitcheck/global/policy/Policy.java
+++ b/src/main/java/katopia/fitcheck/global/policy/Policy.java
@@ -63,6 +63,9 @@ public final class Policy {
     public static final Duration JWT_REFRESH_TOKEN_TTL = Duration.ofDays(14);
     public static final Duration JWT_REGISTRATION_TOKEN_TTL = Duration.ofMinutes(10);
 
+    // SSE policy
+    public static final Duration SSE_TIMEOUT = Duration.ofHours(1);
+
     // descriptions
     public static final String NICKNAME_DES =
             "닉네임 (한글/영문/숫자/._, 최대 " + NICKNAME_MAX_LENGTH + "자)";

--- a/src/main/java/katopia/fitcheck/service/notification/NotificationSseService.java
+++ b/src/main/java/katopia/fitcheck/service/notification/NotificationSseService.java
@@ -1,63 +1,25 @@
 package katopia.fitcheck.service.notification;
 
 import katopia.fitcheck.dto.notification.response.NotificationSummary;
-import lombok.extern.slf4j.Slf4j;
+import katopia.fitcheck.service.sse.AbstractSseService;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 @Service
-@Slf4j
-public class NotificationSseService {
+public class NotificationSseService extends AbstractSseService<NotificationSummary> {
 
-    private static final long TIMEOUT_MS = 60L * 60L * 1000L;
     private static final String EVENT_NAME = "notification";
 
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
-
-    public SseEmitter connect(Long memberId, List<NotificationSummary> unreadSummaries) {
-        SseEmitter emitter = new SseEmitter(TIMEOUT_MS);
-        SseEmitter existing = emitters.put(memberId, emitter);
-        if (existing != null) {
-            existing.complete();
-        }
-        emitter.onCompletion(() -> emitters.remove(memberId, emitter));
-        emitter.onTimeout(() -> {
-            emitters.remove(memberId, emitter);
-            emitter.complete();
-        });
-        emitter.onError(ex -> emitters.remove(memberId, emitter));
-        sendInitialUnread(memberId, unreadSummaries);
-        return emitter;
+    @Override
+    protected String eventName() {
+        return EVENT_NAME;
     }
 
-    public void send(Long memberId, NotificationSummary summary) {
-        SseEmitter emitter = emitters.get(memberId);
-        if (emitter == null) {
-            return;
-        }
-        try {
-            emitter.send(SseEmitter.event()
-                    .name(EVENT_NAME)
-                    .id(String.valueOf(summary.id()))
-                    .data(summary));
-        } catch (IOException ex) {
-            emitters.remove(memberId, emitter);
-            emitter.completeWithError(ex);
-            log.debug("SSE send failed for memberId={}", memberId, ex);
-        }
-    }
-
-    private void sendInitialUnread(Long memberId, List<NotificationSummary> unreadSummaries) {
-        if (unreadSummaries == null || unreadSummaries.isEmpty()) {
-            return;
-        }
-        for (NotificationSummary summary : unreadSummaries) {
-            send(memberId, summary);
-        }
+    @Override
+    protected SseEmitter.SseEventBuilder toEvent(NotificationSummary payload) {
+        return SseEmitter.event()
+                .name(EVENT_NAME)
+                .id(String.valueOf(payload.id()))
+                .data(payload);
     }
 }

--- a/src/main/java/katopia/fitcheck/service/sse/AbstractSseService.java
+++ b/src/main/java/katopia/fitcheck/service/sse/AbstractSseService.java
@@ -1,0 +1,63 @@
+package katopia.fitcheck.service.sse;
+
+import katopia.fitcheck.global.policy.Policy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+public abstract class AbstractSseService<T> {
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter connect(Long memberId, List<T> initialPayloads) {
+        SseEmitter emitter = new SseEmitter(Policy.SSE_TIMEOUT.toMillis());
+        SseEmitter existing = emitters.put(memberId, emitter);
+        if (existing != null) {
+            existing.complete();
+        }
+        emitter.onCompletion(() -> emitters.remove(memberId, emitter));
+        emitter.onTimeout(() -> {
+            emitters.remove(memberId, emitter);
+            emitter.complete();
+        });
+        emitter.onError(ex -> emitters.remove(memberId, emitter));
+        sendInitial(memberId, initialPayloads);
+        return emitter;
+    }
+
+    public void send(Long memberId, T payload) {
+        SseEmitter emitter = emitters.get(memberId);
+        if (emitter == null) {
+            return;
+        }
+        try {
+            emitter.send(toEvent(payload));
+        } catch (IOException ex) {
+            emitters.remove(memberId, emitter);
+            emitter.completeWithError(ex);
+            log.debug("SSE send failed for memberId={}", memberId, ex);
+        }
+    }
+
+    protected abstract String eventName();
+
+    protected SseEmitter.SseEventBuilder toEvent(T payload) {
+        return SseEmitter.event()
+                .name(eventName())
+                .data(payload);
+    }
+
+    protected void sendInitial(Long memberId, List<T> initialPayloads) {
+        if (initialPayloads == null || initialPayloads.isEmpty()) {
+            return;
+        }
+        for (T payload : initialPayloads) {
+            send(memberId, payload);
+        }
+    }
+}


### PR DESCRIPTION
# 작업 개요
- `refactor`: [refactor: OCP 기반 SSE 공통 로직 분리](https://github.com/100-hours-a-week/16-team-katopia-be/commit/823b4b1dd2f14b9a944350b84d3eac6cd8322e67): 일반 알림과 채팅 알림 정책 분리에 의한 리팩토링

### 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 코드 추가
- [ ] 기타

### 기존 흐름

```mermaid
flowchart TD
  S[NotificationSseService]
  S --> E[SseEmitter 관리]
  S --> I[미읽음 초기 전송]
  S --> D[단건 전송]
  S --> B[SSE 알림 이벤트 빌드]
```
### 변경 후 흐름

```mermaid
flowchart LR
    N[NotificationSseService]
    CH[ChatSseService]
    A --> N --> B1[SSE 알림 이벤트 빌드]
    A --> CH --> B2[SSE 채팅 이벤트 빌드]

    subgraph A[AbstractSseService]
      E[SseEmitter 관리]
      I[미읽음 초기 전송]
      D[단건 전송]
    end

```
## ⚠️ 주의사항
- [x] 배포: 개발 서버 배포