### PR TITLE
fix: 좋아요 누른 사용자가 게시글 작성자와 같으면 알림 미발행

### DIFF
--- a/src/main/java/katopia/fitcheck/service/notification/NotificationCommandService.java
+++ b/src/main/java/katopia/fitcheck/service/notification/NotificationCommandService.java
@@ -33,6 +33,11 @@ public class NotificationCommandService {
     @Transactional
     public void publishPostLikeNotification(Long actorId, Long postId) {
         Long recipientId = postFinder.findMemberIdByPostIdOrThrow(postId);
+
+        // 좋아요 누른 사용자가 게시글 작성자와 같으면 알림 미발행
+        if (actorId.equals(recipientId)) {
+            return;
+        }
         Member actor = memberFinder.findByIdOrThrow(actorId);
         String imageObjectKeySnapshot = resolveImageObjectKeySnapshot(NotificationType.POST_LIKE, actor, postId);
         MessageEvent event = MessageEventFactory.postLiked(actor, recipientId, postId, imageObjectKeySnapshot);

--- a/src/test/java/katopia/fitcheck/service/notification/NotificationCommandServiceTest.java
+++ b/src/test/java/katopia/fitcheck/service/notification/NotificationCommandServiceTest.java
@@ -24,10 +24,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationCommandServiceTest {
@@ -122,6 +119,16 @@ class NotificationCommandServiceTest {
             assertThat(event.getRefId()).isEqualTo(REFERENCE_ID);
             NotificationPayload payload = (NotificationPayload) event.getPayload();
             assertThat(payload.getImageObjectKeySnapshot()).isEqualTo(IMAGE_OBJECT_KEY);
+        }
+
+        @Test
+        @DisplayName("TC-TRIGGER-F-03 게시글 좋아요가 본인 게시글이면 알림 미발행")
+        void tcTriggerF03_publishPostLikeNotification_skipsSelfLike() {
+            when(postFinder.findMemberIdByPostIdOrThrow(REFERENCE_ID)).thenReturn(ACTOR_ID);
+
+            notificationService.publishPostLikeNotification(ACTOR_ID, REFERENCE_ID);
+
+            verifyNoInteractions(batchEventPublisher);
         }
 
         @Test


### PR DESCRIPTION
# 작업 개요
- `fix`: [fix: 좋아요 누른 사용자가 게시글 작성자와 같으면 알림 미발행](https://github.com/100-hours-a-week/16-team-katopia-be/commit/ded9ad65fe287771cb5fa87945dbf1b493361882)

### 변경 사항
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [x] 테스트 코드 추가
- [ ] 기타


---

## Test
- [x] 단위 테스트 통과
- [x] 로컬 환경 테스트 완료
- [x] 주요 시나리오 수동 테스트 완료
