### PR TITLE
feat: 게시글 메타 정보(좋아요/북마크 여부) 제공 api 추가

### DIFF
--- a/docs/domain-tech-spec/POST_TECH_SPEC.md
+++ b/docs/domain-tech-spec/POST_TECH_SPEC.md
@@ -83,6 +83,7 @@ CREATE TABLE post_likes (
 - 게시글 작성: `POST /api/posts`
 - 게시글 목록: `GET /api/posts`
 - 게시글 상세: `GET /api/posts/{id}`
+- 게시글 좋아요/북마크 상태: `GET /api/posts/{id}/viewer-state`
 - 홈 피드(팔로우+내 게시글): `GET /api/home/posts`
 - 게시글 수정: `PATCH /api/posts/{id}`
 - 게시글 삭제: `DELETE /api/posts/{id}`

--- a/src/main/java/katopia/fitcheck/controller/PostController.java
+++ b/src/main/java/katopia/fitcheck/controller/PostController.java
@@ -15,6 +15,7 @@ import katopia.fitcheck.dto.post.response.PostLikeResponse;
 import katopia.fitcheck.dto.post.response.PostListResponse;
 import katopia.fitcheck.dto.post.request.PostUpdateRequest;
 import katopia.fitcheck.dto.post.response.PostUpdateResponse;
+import katopia.fitcheck.dto.post.response.PostViewerStateResponse;
 import katopia.fitcheck.service.post.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -74,6 +75,17 @@ public class PostController implements PostApiSpec {
         PostDetailResponse body = postService.getDetail(memberId, id);
 
         return APIResponse.ok(PostSuccessCode.POST_FETCHED, body);
+    }
+
+    @GetMapping("/{id}/viewer-state")
+    @Override
+    public ResponseEntity<APIResponse<PostViewerStateResponse>> getViewerState(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @PathVariable("id") Long id
+    ) {
+        Long memberId = securitySupport.findMemberIdOrNull(principal);
+        PostViewerStateResponse body = postService.getViewerState(memberId, id);
+        return APIResponse.ok(PostSuccessCode.POST_VIEWER_STATE_FETCHED, body);
     }
 
 

--- a/src/main/java/katopia/fitcheck/controller/spec/PostApiSpec.java
+++ b/src/main/java/katopia/fitcheck/controller/spec/PostApiSpec.java
@@ -18,6 +18,7 @@ import katopia.fitcheck.dto.post.response.PostLikeResponse;
 import katopia.fitcheck.dto.post.response.PostListResponse;
 import katopia.fitcheck.dto.post.request.PostUpdateRequest;
 import katopia.fitcheck.dto.post.response.PostUpdateResponse;
+import katopia.fitcheck.dto.post.response.PostViewerStateResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,6 +50,14 @@ public interface PostApiSpec {
     @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공", content = @Content(schema = @Schema(implementation = PostDetailResponse.class)))
     @ApiResponse(responseCode = "404", description = Docs.NOT_FOUND_DES, content = @Content)
     ResponseEntity<APIResponse<PostDetailResponse>> getPost(
+            @AuthenticationPrincipal MemberPrincipal principal,
+            @PathVariable("id") Long id
+    );
+
+    @Operation(summary = "게시글 좋아요/북마크 상태 조회", description = "비로그인 사용자는 false로 응답합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 좋아요/북마크 상태 조회 성공", content = @Content(schema = @Schema(implementation = PostViewerStateResponse.class)))
+    @ApiResponse(responseCode = "404", description = Docs.NOT_FOUND_DES, content = @Content)
+    ResponseEntity<APIResponse<PostViewerStateResponse>> getViewerState(
             @AuthenticationPrincipal MemberPrincipal principal,
             @PathVariable("id") Long id
     );

--- a/src/main/java/katopia/fitcheck/dto/post/response/PostViewerStateResponse.java
+++ b/src/main/java/katopia/fitcheck/dto/post/response/PostViewerStateResponse.java
@@ -1,0 +1,19 @@
+package katopia.fitcheck.dto.post.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import katopia.fitcheck.global.docs.Docs;
+import lombok.Builder;
+
+@Builder
+public record PostViewerStateResponse(
+        @Schema(description = Docs.ID_DES, example = "1")
+        Long id,
+        @Schema(description = "게시글 좋아요 여부", example = "false")
+        boolean isLiked,
+        @Schema(description = "게시글 북마크 여부", example = "false")
+        boolean isBookmarked
+) {
+    public static PostViewerStateResponse of(Long postId, boolean isLiked, boolean isBookmarked) {
+        return new PostViewerStateResponse(postId, isLiked, isBookmarked);
+    }
+}

--- a/src/main/java/katopia/fitcheck/global/config/SecurityConfig.java
+++ b/src/main/java/katopia/fitcheck/global/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                     auth.requestMatchers(HttpMethod.GET, "/api/members/*").permitAll();
                     auth.requestMatchers(HttpMethod.GET, "/api/members/*/posts").permitAll();
                     auth.requestMatchers(HttpMethod.GET, "/api/posts/*").permitAll();
+                    auth.requestMatchers(HttpMethod.GET, "/api/posts/*/viewer-state").permitAll();
                     auth.requestMatchers(HttpMethod.GET, "/api/posts/*/comments").permitAll();
                     auth.requestMatchers(HttpMethod.GET, "/api/members/me").authenticated();
                     auth.requestMatchers(HttpMethod.POST, "/api/auth/tokens").permitAll();   // RTR

--- a/src/main/java/katopia/fitcheck/global/exception/code/PostSuccessCode.java
+++ b/src/main/java/katopia/fitcheck/global/exception/code/PostSuccessCode.java
@@ -11,7 +11,8 @@ public enum PostSuccessCode implements ResponseCode {
     POST_LISTED(HttpStatus.OK, "POST-S-002", "게시글 목록 조회를 완료되었습니다."),
     POST_FETCHED(HttpStatus.OK, "POST-S-003", "게시글 상세 조회를 완료되었습니다."),
     POST_UPDATED(HttpStatus.OK, "POST-S-004", "게시글이 수정되었습니다."),
-    POST_DELETED(HttpStatus.NO_CONTENT, "POST-S-005", "게시글이 삭제되었습니다.");
+    POST_DELETED(HttpStatus.NO_CONTENT, "POST-S-005", "게시글이 삭제되었습니다."),
+    POST_VIEWER_STATE_FETCHED(HttpStatus.OK, "POST-S-006", "게시글 좋아요/북마크 상태 조회를 완료되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/katopia/fitcheck/service/post/PostSearchService.java
+++ b/src/main/java/katopia/fitcheck/service/post/PostSearchService.java
@@ -9,6 +9,7 @@ import katopia.fitcheck.dto.post.response.PostDetailResponse;
 import katopia.fitcheck.dto.post.response.PostResponse;
 import katopia.fitcheck.dto.post.response.PostListResponse;
 import katopia.fitcheck.dto.post.response.PostSummary;
+import katopia.fitcheck.dto.post.response.PostViewerStateResponse;
 import katopia.fitcheck.repository.member.MemberFollowRepository;
 import katopia.fitcheck.repository.post.PostBookmarkRepository;
 import katopia.fitcheck.repository.post.PostRepository;
@@ -81,6 +82,14 @@ public class PostSearchService {
         boolean isLiked = memberId != null && postLikeRepository.existsByMemberIdAndPostId(memberId, postId);
         boolean isBookmarked = memberId != null && postBookmarkRepository.existsByMemberIdAndPostId(memberId, postId);
         return PostDetailResponse.of(post, author, tags, isLiked, isBookmarked);
+    }
+
+    @Transactional(readOnly = true)
+    public PostViewerStateResponse getViewerState(Long memberId, Long postId) {
+        postFinder.requireExists(postId);
+        boolean isLiked = memberId != null && postLikeRepository.existsByMemberIdAndPostId(memberId, postId);
+        boolean isBookmarked = memberId != null && postBookmarkRepository.existsByMemberIdAndPostId(memberId, postId);
+        return PostViewerStateResponse.of(postId, isLiked, isBookmarked);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/katopia/fitcheck/service/post/PostService.java
+++ b/src/main/java/katopia/fitcheck/service/post/PostService.java
@@ -7,6 +7,7 @@ import katopia.fitcheck.dto.post.response.PostResponse;
 import katopia.fitcheck.dto.post.response.PostLikeResponse;
 import katopia.fitcheck.dto.post.response.PostBookmarkResponse;
 import katopia.fitcheck.dto.post.response.PostListResponse;
+import katopia.fitcheck.dto.post.response.PostViewerStateResponse;
 import katopia.fitcheck.dto.post.request.PostUpdateRequest;
 import katopia.fitcheck.dto.post.response.PostUpdateResponse;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,10 @@ public class PostService {
 
     public PostDetailResponse getDetail(Long memberId, Long postId) {
         return postSearchService.getDetail(memberId, postId);
+    }
+
+    public PostViewerStateResponse getViewerState(Long memberId, Long postId) {
+        return postSearchService.getViewerState(memberId, postId);
     }
 
     public PostResponse listHomeFeed(Long memberId, String sizeValue, String after) {


### PR DESCRIPTION
# 작업 개요
- `feat` : [feat: 게시글 메타 정보(좋아요/북마크 여부) 제공 api 추가](https://github.com/100-hours-a-week/16-team-katopia-be/commit/48afe930fe1a33402749c9b0de7dfebdbd391d93)

### 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 코드 추가
- [ ] 기타


---

## Test
- [x] 단위 테스트 통과
- [x] 로컬 환경 테스트 완료
- [x] 주요 시나리오 수동 테스트 완료


## ⚠️ 주의사항
- [x] 배포: 개발 서버 테스트 예정
- [ ] DB: 변경사항 없음.
- [x] API: 기존 게시글 상세보기 api 는 유지, 신규 api 추가






