### PR TITLE
chore: SSE 연결 부하 테스트 설정

### DIFF
--- a/src/main/java/katopia/fitcheck/global/policy/Policy.java
+++ b/src/main/java/katopia/fitcheck/global/policy/Policy.java
@@ -69,7 +69,7 @@ public final class Policy {
 
     // SSE policy
     public static final Duration
-            ALB_CONNECTION_IDLE_TIMEOUT = Duration.ofMinutes(10),
+            ALB_CONNECTION_IDLE_TIMEOUT = Duration.ofMinutes(2),
             SSE_TIMEOUT = Duration.ofMinutes(5),
             SSE_CLEANUP_INTERVAL = SSE_TIMEOUT.multipliedBy(2),
             SSE_HEARTBEAT_INTERVAL = ALB_CONNECTION_IDLE_TIMEOUT.minusSeconds(20);


### PR DESCRIPTION
# 작업 개요(#issue_number)
- [chore: SSE 연결 부하 테스트 설정](https://github.com/100-hours-a-week/16-team-katopia-be/commit/594373f465b1c35d9712aa340d65f3fac04c8ad2)

### 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 코드 추가
- [x] 기타


---

## ⚠️ 주의사항
- [x] 배포: SSE 연결 객체 기본 수명 2분으로 임시 변경






