### PR TITLE
refactor: 알림 전송/저장 비동기 분리

### DIFF
--- a/src/main/java/katopia/fitcheck/global/config/AsyncConfig.java
+++ b/src/main/java/katopia/fitcheck/global/config/AsyncConfig.java
@@ -3,8 +3,11 @@ package katopia.fitcheck.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.core.task.support.TaskExecutorAdapter;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Configuration
 @EnableAsync
@@ -12,12 +15,9 @@ public class AsyncConfig {
 
     @Bean(name = "notificationSendExecutor")
     public TaskExecutor notificationSendExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(8);
-        executor.setMaxPoolSize(16);
-        executor.setQueueCapacity(2000);
-        executor.setThreadNamePrefix("notify-send-");
-        executor.initialize();
-        return executor;
+        ExecutorService executor = Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual().name("notify-send-", 0).factory()
+        );
+        return new TaskExecutorAdapter(executor);
     }
 }

--- a/src/main/java/katopia/fitcheck/redis/config/NotificationRedisPubSubConfig.java
+++ b/src/main/java/katopia/fitcheck/redis/config/NotificationRedisPubSubConfig.java
@@ -1,0 +1,36 @@
+package katopia.fitcheck.redis.config;
+
+import katopia.fitcheck.redis.notification.RedisNotificationRealtimePublisher;
+import katopia.fitcheck.redis.notification.RedisNotificationRealtimeSubscriber;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class NotificationRedisPubSubConfig {
+
+    @Bean
+    public MessageListenerAdapter notificationRealtimeListener(RedisNotificationRealtimeSubscriber subscriber) {
+        MessageListenerAdapter adapter = new MessageListenerAdapter(subscriber, "handleMessage");
+        adapter.setSerializer(new StringRedisSerializer());
+        return adapter;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer notificationRedisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter notificationRealtimeListener
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(
+                notificationRealtimeListener,
+                new ChannelTopic(RedisNotificationRealtimePublisher.CHANNEL)
+        );
+        return container;
+    }
+}

--- a/src/main/java/katopia/fitcheck/redis/notification/NotificationRealtimeEnvelope.java
+++ b/src/main/java/katopia/fitcheck/redis/notification/NotificationRealtimeEnvelope.java
@@ -1,0 +1,9 @@
+package katopia.fitcheck.redis.notification;
+
+import katopia.fitcheck.dto.notification.response.NotificationSummary;
+
+public record NotificationRealtimeEnvelope(
+        Long recipientId,
+        NotificationSummary payload
+) {
+}

--- a/src/main/java/katopia/fitcheck/redis/notification/RedisNotificationRealtimePublisher.java
+++ b/src/main/java/katopia/fitcheck/redis/notification/RedisNotificationRealtimePublisher.java
@@ -1,0 +1,32 @@
+package katopia.fitcheck.redis.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import katopia.fitcheck.dto.notification.response.NotificationSummary;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisNotificationRealtimePublisher {
+
+    public static final String CHANNEL = "notification:realtime";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void publish(Long recipientId, NotificationSummary payload) {
+        try {
+            String message = objectMapper.writeValueAsString(
+                    new NotificationRealtimeEnvelope(recipientId, payload)
+            );
+            stringRedisTemplate.convertAndSend(CHANNEL, message);
+        } catch (JsonProcessingException e) {
+            log.error("[NOTIFICATION-REDIS] publish failed recipientId={}", recipientId, e);
+            throw new IllegalStateException("Failed to publish notification realtime event.", e);
+        }
+    }
+}

--- a/src/main/java/katopia/fitcheck/redis/notification/RedisNotificationRealtimeSubscriber.java
+++ b/src/main/java/katopia/fitcheck/redis/notification/RedisNotificationRealtimeSubscriber.java
@@ -1,0 +1,30 @@
+package katopia.fitcheck.redis.notification;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import katopia.fitcheck.service.notification.NotificationSseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class RedisNotificationRealtimeSubscriber {
+
+    private final NotificationSseService notificationSseService;
+    private final ObjectMapper objectMapper;
+
+    public void handleMessage(String message) {
+        try {
+            NotificationRealtimeEnvelope envelope = objectMapper.readValue(message, NotificationRealtimeEnvelope.class);
+            if (envelope.recipientId() == null || envelope.payload() == null) {
+                log.warn("[NOTIFICATION-REDIS] invalid envelope recipientId={}", envelope.recipientId());
+                return;
+            }
+            notificationSseService.send(envelope.recipientId(), envelope.payload());
+        } catch (JsonProcessingException e) {
+            log.error("[NOTIFICATION-REDIS] subscribe handle failed message={}", message, e);
+        }
+    }
+}

--- a/src/main/java/katopia/fitcheck/service/notification/SseNotificationPublisher.java
+++ b/src/main/java/katopia/fitcheck/service/notification/SseNotificationPublisher.java
@@ -2,6 +2,7 @@ package katopia.fitcheck.service.notification;
 
 import katopia.fitcheck.domain.notification.Notification;
 import katopia.fitcheck.dto.notification.response.NotificationSummary;
+import katopia.fitcheck.redis.notification.RedisNotificationRealtimePublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -11,13 +12,13 @@ import org.springframework.stereotype.Component;
 @Slf4j
 public class SseNotificationPublisher implements NotificationRealtimePublisher {
 
-    private final NotificationSseService notificationSseService;
+    private final RedisNotificationRealtimePublisher redisNotificationRealtimePublisher;
 
     @Override
     public void publish(Notification notification) {
         try {
             NotificationSummary summary = NotificationSummary.of(notification);
-            notificationSseService.send(notification.getRecipient().getId(), summary);
+            redisNotificationRealtimePublisher.publish(notification.getRecipient().getId(), summary);
         } catch (Exception ex) {
             log.warn("Failed to send realtime notification. notificationId={}", notification.getId(), ex);
         }

--- a/src/test/java/katopia/fitcheck/redis/notification/RedisNotificationRealtimeSubscriberTest.java
+++ b/src/test/java/katopia/fitcheck/redis/notification/RedisNotificationRealtimeSubscriberTest.java
@@ -1,0 +1,28 @@
+package katopia.fitcheck.redis.notification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import katopia.fitcheck.dto.notification.response.NotificationSummary;
+import katopia.fitcheck.service.notification.NotificationSseService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class RedisNotificationRealtimeSubscriberTest {
+
+    @Test
+    @DisplayName("TC-NOTIFICATION-SSE-S-06 Redis 알림 이벤트 수신 시 recipient 기준으로 SSE 전송")
+    void tcNotificationSseS06_handleMessage_sendsToRecipient() throws Exception {
+        NotificationSseService notificationSseService = mock(NotificationSseService.class);
+        ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        RedisNotificationRealtimeSubscriber subscriber = new RedisNotificationRealtimeSubscriber(notificationSseService, objectMapper);
+
+        NotificationSummary payload = NotificationSummary.builder().id(1L).build();
+        String message = objectMapper.writeValueAsString(new NotificationRealtimeEnvelope(7L, payload));
+
+        subscriber.handleMessage(message);
+
+        verify(notificationSseService).send(7L, payload);
+    }
+}

--- a/src/test/java/katopia/fitcheck/service/notification/SseNotificationPublisherTest.java
+++ b/src/test/java/katopia/fitcheck/service/notification/SseNotificationPublisherTest.java
@@ -4,6 +4,7 @@ import katopia.fitcheck.domain.member.Member;
 import katopia.fitcheck.domain.notification.Notification;
 import katopia.fitcheck.domain.notification.NotificationType;
 import katopia.fitcheck.global.policy.Policy;
+import katopia.fitcheck.redis.notification.RedisNotificationRealtimePublisher;
 import katopia.fitcheck.support.MemberTestFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +19,8 @@ class SseNotificationPublisherTest {
     @Test
     @DisplayName("TC-NOTIFICATION-SSE-S-04 SSE 발행은 수신자 기준으로 전송")
     void tcNotificationSseS04_publish_sendsToRecipient() {
-        NotificationSseService sseService = mock(NotificationSseService.class);
-        SseNotificationPublisher publisher = new SseNotificationPublisher(sseService);
+        RedisNotificationRealtimePublisher redisPublisher = mock(RedisNotificationRealtimePublisher.class);
+        SseNotificationPublisher publisher = new SseNotificationPublisher(redisPublisher);
 
         Member recipient = MemberTestFactory.member(1L);
         Notification notification = Notification.of(
@@ -34,7 +35,7 @@ class SseNotificationPublisherTest {
         publisher.publish(notification);
 
         ArgumentCaptor<Long> memberIdCaptor = ArgumentCaptor.forClass(Long.class);
-        verify(sseService).send(memberIdCaptor.capture(), org.mockito.ArgumentMatchers.any());
+        verify(redisPublisher).publish(memberIdCaptor.capture(), org.mockito.ArgumentMatchers.any());
         assertThat(memberIdCaptor.getValue()).isEqualTo(1L);
     }
 }


### PR DESCRIPTION
# 작업 개요
- `refactor`: [refactor: 알림 전송/저장 비동기 분리](https://github.com/100-hours-a-week/16-team-katopia-be/commit/f9eb40dc5901c0dee7587f01750010b230fe3407)

### 변경 사항
- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 코드 추가
- [ ] 기타

## ⚠️ 주의사항
- [x] 배포: 개발 서버 인프라 점검 예정