### PR TITLE
feat/noti 알림 전송/저장 비동기 분리

### DIFF
--- a/docs/domain-tech-spec/ASYNC_TECH_SPEC.md
+++ b/docs/domain-tech-spec/ASYNC_TECH_SPEC.md
@@ -146,6 +146,63 @@ flowchart TD
   PubSub --> SSE[SSE Realtime Publisher]
 ```
 
+### 실시간 알림 저장/전송 흐름(구현 상세)
+```mermaid
+graph LR
+		subgraph Trigger [Notification Trigger Event]
+			SingleTargetEvent@{ shape: event, label: "Single Target"}
+			MultiTargetEvent@{ shape: event, label: "Multi Target"}
+		end
+
+		SingleTargetEvent move@=="Pub"==> BatchQueue
+    move@{ animation: fast }
+
+		MultiTargetEvent move1@=="Pub"==> TargetQueue
+		move1@{ animation: fast }
+
+    subgraph Message_Queue [Message Queue]
+        TargetQueue@{ shape: das, label: "Target Queue" }
+        BatchQueue@{ shape: das, label: "Batch Queue" }
+    end
+
+    subgraph logicalGraph [ ]
+      Message_Queue
+	    TargetConsumer@{ shape: procs, label: "Target Consumer"}
+	    BatchConsumer@{ shape: procs, label: "Batch Consumer"}
+    end
+
+    TargetQueue move2@==> TargetConsumer
+    TargetConsumer move3@=="Pub"==> BatchQueue
+		move2@{ animation: fast }
+		move3@{ animation: fast }
+
+
+    Database[(Database)]
+    Redis@{ shape: hex, label: "Redis Pub/Sub" }
+
+    BatchConsumer --"1️⃣ save"--> Database
+    BatchQueue -."2️⃣ Ack after save".- BatchConsumer
+    BatchQueue ----> BatchConsumer
+    BatchConsumer -- "3️⃣ async send" --> Redis
+
+    subgraph logicalGraph2 [ ]
+	    Redis --> ServerA --> User
+	    Redis --> ServerB --> User
+	    User((SSE Clients))
+    end
+
+
+style logicalGraph fill:none,stroke:none
+style logicalGraph2 fill:none,stroke:none
+style Message_Queue fill:#f5f5f5,stroke:#333
+style TargetQueue fill:#fff,stroke:#333
+style BatchQueue fill:#fff,stroke:#333
+style Database fill:#e1f5fe,stroke:#01579b
+style Trigger fill:#fff3e0,stroke:#ff6f00
+
+
+```
+
 ### 보장 수준
 - 실시간 전송: best-effort
 - 알림 저장: at-least-once

--- a/src/main/java/katopia/fitcheck/service/notification/SseNotificationPublisher.java
+++ b/src/main/java/katopia/fitcheck/service/notification/SseNotificationPublisher.java
@@ -5,6 +5,7 @@ import katopia.fitcheck.dto.notification.response.NotificationSummary;
 import katopia.fitcheck.redis.notification.RedisNotificationRealtimePublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,6 +16,7 @@ public class SseNotificationPublisher implements NotificationRealtimePublisher {
     private final RedisNotificationRealtimePublisher redisNotificationRealtimePublisher;
 
     @Override
+    @Async("notificationSendExecutor")
     public void publish(Notification notification) {
         try {
             NotificationSummary summary = NotificationSummary.of(notification);


### PR DESCRIPTION
# 작업 개요
- `refactor`: [refactor: 알림 전송/저장 비동기 분리 활성화](https://github.com/100-hours-a-week/16-team-katopia-be/commit/fb6cbaa08c6ff9fe78052b208f256e2e2746074d)

### 변경 사항
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 테스트 코드 추가
- [ ] 기타